### PR TITLE
Add another timezone name

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -50,7 +50,7 @@ validateTZ <- function(tz)
   else if(tz %in% c("PST", "PDT"))
     tz <- "America/Los_Angeles"
 
-  else if(tz %in% c("CET", "CEST"))
+  else if(tz %in% c("CET", "CEST", "Central European Time"))
     tz <- "Europe/Paris"
 
   else if(tz %in% c("BST", "British Summer Time", "Greenwich Mean Time"))


### PR DESCRIPTION
Avoid error as in 
```
Server Version and Timestamp: 142 20191122 21:57:19 Central European Time 
Error in validateTZ(substr(s, 19L, nchar(s))) : 
  tz %in% OlsonNames() is not TRUE
```